### PR TITLE
Refactor subtool Mains to use span<string_view> instead of argc/argv

### DIFF
--- a/src/tools/callgraph.cc
+++ b/src/tools/callgraph.cc
@@ -69,19 +69,19 @@ struct Tool {
   std::set<std::pair<Index, Index>> call_graph;
 };
 
-int Main(int argc, char** argv) {
+int Main(span<string_view> const& args) {
   string_view filename;
   Options options;
   options.features.EnableAll();
 
-  for (int i = 0; i < argc; ++i) {
-    string_view arg = argv[i];
+  for (int i = 0; i < args.size(); ++i) {
+    string_view arg = args[i];
     if (arg[0] == '-') {
       switch (arg[1]) {
-        case 'o': options.output_filename = argv[++i]; break;
+        case 'o': options.output_filename = args[++i]; break;
         case '-':
           if (arg == "--output") {
-            options.output_filename = argv[++i];
+            options.output_filename = args[++i];
           } else {
             print(stderr, "Unknown long argument {}\n", arg);
           }

--- a/src/tools/callgraph.h
+++ b/src/tools/callgraph.h
@@ -17,11 +17,14 @@
 #ifndef WASP_TOOLS_CALLGRAPH_H_
 #define WASP_TOOLS_CALLGRAPH_H_
 
+#include "wasp/base/span.h"
+#include "wasp/base/string_view.h"
+
 namespace wasp {
 namespace tools {
 namespace callgraph {
 
-int Main(int argc, char** argv);
+int Main(span<string_view> const& args);
 
 }  // namespace callgraph
 }  // namespace tools

--- a/src/tools/cfg.cc
+++ b/src/tools/cfg.cc
@@ -108,22 +108,22 @@ struct Tool {
   BBID current_bbid = InvalidBBID;
 };
 
-int Main(int argc, char** argv) {
+int Main(span<string_view> const& args) {
   string_view filename;
   Options options;
   options.features.EnableAll();
 
-  for (int i = 0; i < argc; ++i) {
-    string_view arg = argv[i];
+  for (int i = 0; i < args.size(); ++i) {
+    string_view arg = args[i];
     if (arg[0] == '-') {
       switch (arg[1]) {
-        case 'o': options.output_filename = argv[++i]; break;
-        case 'f': options.function = argv[++i]; break;
+        case 'o': options.output_filename = args[++i]; break;
+        case 'f': options.function = args[++i]; break;
         case '-':
           if (arg == "--output") {
-            options.output_filename = argv[++i];
+            options.output_filename = args[++i];
           } else if (arg == "--function") {
-            options.function = argv[++i];
+            options.function = args[++i];
           } else {
             print(stderr, "Unknown long argument {}\n", arg);
           }

--- a/src/tools/cfg.h
+++ b/src/tools/cfg.h
@@ -17,11 +17,14 @@
 #ifndef WASP_TOOLS_CFG_H_
 #define WASP_TOOLS_CFG_H_
 
+#include "wasp/base/span.h"
+#include "wasp/base/string_view.h"
+
 namespace wasp {
 namespace tools {
 namespace cfg {
 
-int Main(int argc, char** argv);
+int Main(span<string_view> const& args);
 
 }  // namespace cfg
 }  // namespace tools

--- a/src/tools/dfg.cc
+++ b/src/tools/dfg.cc
@@ -153,22 +153,22 @@ struct Tool {
   ValueID undef = InvalidValueID;
 };
 
-int Main(int argc, char** argv) {
+int Main(span<string_view> const& args) {
   string_view filename;
   Options options;
   options.features.EnableAll();
 
-  for (int i = 0; i < argc; ++i) {
-    string_view arg = argv[i];
+  for (int i = 0; i < args.size(); ++i) {
+    string_view arg = args[i];
     if (arg[0] == '-') {
       switch (arg[1]) {
-        case 'o': options.output_filename = argv[++i]; break;
-        case 'f': options.function = argv[++i]; break;
+        case 'o': options.output_filename = args[++i]; break;
+        case 'f': options.function = args[++i]; break;
         case '-':
           if (arg == "--output") {
-            options.output_filename = argv[++i];
+            options.output_filename = args[++i];
           } else if (arg == "--function") {
-            options.function = argv[++i];
+            options.function = args[++i];
           } else {
             print(stderr, "Unknown long argument {}\n", arg);
           }

--- a/src/tools/dfg.h
+++ b/src/tools/dfg.h
@@ -17,11 +17,14 @@
 #ifndef WASP_TOOLS_DFG_H_
 #define WASP_TOOLS_DFG_H_
 
+#include "wasp/base/span.h"
+#include "wasp/base/string_view.h"
+
 namespace wasp {
 namespace tools {
 namespace dfg {
 
-int Main(int argc, char** argv);
+int Main(span<string_view> const& args);
 
 }  // namespace dfg
 }  // namespace tools

--- a/src/tools/dump.cc
+++ b/src/tools/dump.cc
@@ -188,20 +188,20 @@ struct Tool {
 // static
 constexpr int Tool::max_octets_per_line;
 
-int Main(int argc, char** argv) {
+int Main(span<string_view> const& args) {
   std::vector<string_view> filenames;
   Options options;
   options.features.EnableAll();
 
-  for (int i = 0; i < argc; ++i) {
-    string_view arg = argv[i];
+  for (int i = 0; i < args.size(); ++i) {
+    string_view arg = args[i];
     if (arg[0] == '-') {
       switch (arg[1]) {
         case 'h': options.print_headers = true; break;
         case 'd': options.print_disassembly = true; break;
         case 'x': options.print_details = true; break;
         case 's': options.print_raw_data = true; break;
-        case 'j': options.section_name = argv[++i]; break;
+        case 'j': options.section_name = args[++i]; break;
         case '-':
           if (arg == "--headers") {
             options.print_headers = true;
@@ -212,7 +212,7 @@ int Main(int argc, char** argv) {
           } else if (arg == "--full-contents") {
             options.print_raw_data = true;
           } else if (arg == "--section") {
-            options.section_name = argv[++i];
+            options.section_name = args[++i];
           } else {
             print("Unknown long argument {}\n", arg);
           }

--- a/src/tools/dump.h
+++ b/src/tools/dump.h
@@ -17,11 +17,14 @@
 #ifndef WASP_TOOLS_DUMP_H_
 #define WASP_TOOLS_DUMP_H_
 
+#include "wasp/base/span.h"
+#include "wasp/base/string_view.h"
+
 namespace wasp {
 namespace tools {
 namespace dump {
 
-int Main(int argc, char** argv);
+int Main(span<string_view> const& args);
 
 }  // namespace dump
 }  // namespace tools

--- a/src/tools/wasp.cc
+++ b/src/tools/wasp.cc
@@ -19,19 +19,26 @@
 #include "src/tools/dfg.h"
 #include "src/tools/dump.h"
 
+#include "wasp/base/enumerate.h"
 #include "wasp/base/format.h"
 #include "wasp/base/formatters.h"
+#include "wasp/base/span.h"
 #include "wasp/base/string_view.h"
 
 using namespace ::wasp;
 
-using Command = int (*)(int argc, char** argv);
+using Command = int (*)(span<string_view> const& args);
 
 void PrintHelp();
 
 int main(int argc, char** argv) {
+  std::vector<string_view> args(argc - 1);
   for (int i = 1; i < argc; ++i) {
-    string_view arg = argv[i];
+    args[i - 1] = argv[i];
+  }
+
+  for (const auto& argPair : enumerate(args)) {
+    auto arg = argPair.value;
     if (arg[0] == '-') {
       switch (arg[1]) {
         case 'h':
@@ -57,7 +64,8 @@ int main(int argc, char** argv) {
         return 1;
       }
 
-      return command(argc - i - 1, argv + i + 1);
+      span<string_view> argSpan = args;
+      return command(argSpan.subspan(argPair.index));
     }
   }
 


### PR DESCRIPTION
In preparation for a more general option parsing refactor. This doesn't actually change any parsing logic, just the `Main` function interfaces.

Wound up using `enumerate` immediately, so that's fun.